### PR TITLE
Add support for custom phantomjs version

### DIFF
--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -18,7 +18,7 @@ module Phantomjs
     end
 
     def version
-      Phantomjs::VERSION.split('.')[0..-2].join('.')
+      ENV['PHANTOMJS_VERSION'].present? ? ENV['PHANTOMJS_VERSION'] : Phantomjs::VERSION.split('.')[0..-2].join('.')
     end
 
     def path

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -100,7 +100,7 @@ module Phantomjs
         end
 
         def package_url
-          "#{DOWNLOAD_HOST}/phantomjs-1.9.7-linux-x86_64.tar.bz2"
+          "#{DOWNLOAD_HOST}/phantomjs-#{Phantomjs.version}-linux-x86_64.tar.bz2"
         end
       end
     end
@@ -116,7 +116,7 @@ module Phantomjs
         end
 
         def package_url
-          "#{DOWNLOAD_HOST}/phantomjs-1.9.7-linux-i686.tar.bz2"
+          "#{DOWNLOAD_HOST}/phantomjs-#{Phantomjs.version}-linux-i686.tar.bz2"
         end
       end
     end
@@ -132,7 +132,7 @@ module Phantomjs
         end
 
         def package_url
-          "#{DOWNLOAD_HOST}/phantomjs-1.9.7-macosx.zip"
+          "#{DOWNLOAD_HOST}/phantomjs-#{Phantomjs.version}-macosx.zip"
         end
       end
     end
@@ -156,7 +156,7 @@ module Phantomjs
         end
 
         def package_url
-          "#{DOWNLOAD_HOST}/phantomjs-1.9.7-windows.zip"
+          "#{DOWNLOAD_HOST}/phantomjs-#{Phantomjs.version}-windows.zip"
         end
       end
     end


### PR DESCRIPTION
## Problem

Mac OSX Catalina only supports 64-bit binaries. The current phantomjs we are using (1.9.7) is only available in 32-bit version.

## Solution

We can't upgrade to phantomjs 2.1.1 in Circle because it has a memory leak that affects CI, so, for now, we just need to provide a way to customize your own phantomjs version to use in your local env.